### PR TITLE
Large prof class

### DIFF
--- a/R/prof_class.R
+++ b/R/prof_class.R
@@ -181,7 +181,7 @@ prof_class <- function(
   
   
   ### CALCULATIONS ###
-  #tryCatch(
+  tryCatch(
   {
     message("START 'prof_class'.")
     message("")
@@ -449,7 +449,7 @@ prof_class <- function(
       t_help <- rep(1,length(datacolumns))*com_length
       t_help[2:3] <- 1 # dimension attributes need only one value
       #ii: isn't this a copy of profs_resampled_stored, which is then weighted? Do we need this duplication, or
-      #couldn't weight and "unweigh" we the same instance to save memory?
+      #couldn't weight and "unweigh" (if necessary later) we the same instance to save memory?
       profs_resampled <- matrix(0, nrow=n_profs, ncol=sum(t_help*datacolumns*(attr_weights_class!=0)))
       
       
@@ -477,7 +477,7 @@ prof_class <- function(
           dest_column <- dest_column+1
         }
         
-        #ii: isn't this necessary only for cf_mode != 'successive'?
+        #ii: isn't this necessary only for cf_mode != 'successive'? Even in successive, wouldn't it be enough to do it once?
         #treat supp_data if present (resample, weigh and add to profile vector to be included in cluster analysis)
         if (n_suppl_attributes) {
           attr_start_column <- 1+com_length+2   #initial value for first loop
@@ -577,7 +577,6 @@ prof_class <- function(
         plot(1,1,type="n", xlim=c(0,max(profs_resampled_stored[,com_length+1])), ylim=c(0,max(profs_resampled_stored[,com_length+2])),
              main=paste("Original catenas\nclassified according ", attr_names[iw], sep=""), xlab="horizontal length [m]", ylab="elevation [m]")
         for (i in 1:n_profs) {
-          #lines(profsx[[i]], profs[[i]], col=cidx[i])
           lines(   (0:(com_length-1) / (com_length-1)) * profs_resampled_stored[i,com_length+1], 
                 profs_resampled_stored[i,1:com_length] * profs_resampled_stored[i,com_length+2], col=cidx[i])
         }
@@ -1209,19 +1208,19 @@ prof_class <- function(
 
     # if an error occurs...
   
-    }   #, 
-  # error = function(e) {
-  #   
-  #   # stop sinking
-  #   closeAllConnections()
-  #   
-  #   # restore original warning mode
-  #   if(silent)
-  #     options(warn = oldw)
-  #   
-  #   stop(paste(e))  
-  # 
-  #   })
+    }   , 
+  error = function(e) {
+
+    # stop sinking
+    closeAllConnections()
+
+    # restore original warning mode
+    if(silent)
+      options(warn = oldw)
+
+    stop(paste(e))
+
+    })
     
 } # EOF
 

--- a/R/prof_class.R
+++ b/R/prof_class.R
@@ -564,7 +564,9 @@ prof_class <- function(
         {
           dists <- daisy(profs_resampled) # compute pairwise distances, TODO: see warnings
           plot(silhouette(kmeans_out$cluster, dists^2), main=attr_names[iw]) # plot silhouette
-        }  
+        }  else
+          dists <- matrix(-9999, nrow=n_profs, ncol=nclasses)  #dummy, no distance computed
+      
       }
       
       

--- a/R/prof_class.R
+++ b/R/prof_class.R
@@ -564,7 +564,9 @@ prof_class <- function(
         {
           dists <- daisy(profs_resampled) # compute pairwise distances, TODO: see warnings
           plot(silhouette(kmeans_out$cluster, dists^2), main=attr_names[iw]) # plot silhouette
-        }  
+        }  else
+        dists <- rep(-9999,n_profs) #dummy, no distance computed
+      
       }
       
       

--- a/R/prof_class.R
+++ b/R/prof_class.R
@@ -243,9 +243,9 @@ prof_class <- function(
     stats <- scan(catena_file, nlines = 1, what=numeric(), sep = "\t", quiet = TRUE) #read first line only
     stats <- read.table(file = catena_file, colClasses = c("numeric", rep("NULL", length(stats)-1)), sep = "\t") #read first column only
     
-    p_id <- stats[,1] #get IDs
+    p_id = stats[,1]
     rm(stats)
-    p_id_unique = unique(p_id)
+    p_id_unique = unique(p_id) #get unique IDs
 
     if (!is.null(eha_subset)) 
     {
@@ -260,6 +260,7 @@ prof_class <- function(
     n_profs = length(p_id_unique)
     
     profpoints <- table(p_id)  #count number of points of each catena
+    rm(p_id)
     
     # use the median of sampling points as the desired common length of profiles
     if (classify_type != 'load') {  
@@ -528,13 +529,13 @@ prof_class <- function(
         stop("not yet implemented")
       } else {
         # unsupervised classification
-        unique_profs=unique(x=profs_resampled) #ii: avoid duplication of array here, try duplicates()?
-        if (nrow(unique_profs) <= nclasses) #not enough distinct profiles for this attribute 
+        dups = duplicated(profs_resampled)
+        if (nrow(profs_resampled) - sum(dups) <= nclasses) #not enough distinct profiles for this attribute 
         {
           kmeans_out=NULL #disables later plots
           for(jj in 1:nrow(profs_resampled)) 
-            cidx[jj]=which(apply(unique_profs, MARGIN=1, FUN=identical, profs_resampled[jj,]))
-          cmeans2 <- unique_profs # matrix of cluster centers
+            cidx[jj]=which(apply(profs_resampled[!dups,, drop=FALSE], MARGIN=1, FUN=identical, profs_resampled[jj,]))
+          cmeans2 <- profs_resampled[dups,, drop=FALSE] # matrix of cluster centers
           sumd <- 0   # within-cluster sum of squares, one per cluster  
         } else
         { #regular case  


### PR DESCRIPTION
addresses #29 

- successively load rstats.txt and resample each catena: this avoids duplicates in memory
- optionally disable silhouette plot (memory intensive)
- minor clean-up and code commenting

side effects
- minor rounding discrepancies (second decimal) which I couldn't trace back
- plotting of original catenas based on reprojected resampled catenas slightly less accurate (visualisation only)

I guess we can live with these slight discrepancies and merge. 
Still, I did not have the time to do in-depth checks. Beware, if you need 100 % compatibility with older versions.
There is still some potential for improvement which I marked in the code with ii, also noted in #29.